### PR TITLE
Re-enables the map after Respawning from the Quiet Farmhouse

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -399,6 +399,7 @@
           "VITRIFYING"
         ]
       },
+      { "alter_timed_events": "vitrified_farm_escape_key" },
       {
         "run_eocs": [ "EOC_FIX_MAGICLYSM_PROBLEMS", "EOC_FIX_MIND_OVER_MATTER_PROBLEMS", "EOC_FIX_XEDRA_EVOLVED_PROBLEMS" ]
       }


### PR DESCRIPTION
After respawning in the Sky Island, removes the global event which shows that you're in the 'Quiet Farmhouse' in the map.

#### Summary
Bugfixes "Map: Global Event 'Quiet Farmhouse' sticks after respawning, not enabling the map"

#### Purpose of change
Follows up on [#80553](https://github.com/CleverRaven/Cataclysm-DDA/pull/80553)

#### Describe the solution
It removes the altered time event vitrified_farm_escape_key when you respawn, thus reenabling the map

#### Describe alternatives you've considered
None, the solution was suggested in the issue linked here.

#### Testing
Play the sky island mod
Encounter black glass house
Die
Attempt to open the map
See it's the 'Quiet Farmhouse'

#### Additional context
One of my first issues, feel free to tell me if anything is wrong!